### PR TITLE
Improve export to data frame

### DIFF
--- a/uimfpy/UIMFReader.py
+++ b/uimfpy/UIMFReader.py
@@ -323,7 +323,7 @@ class UIMFReader(object):
 
         return xic_by_mzbin
 
-    def get_data_in_deimos_format(self):
+    def to_dataframe(self):
         # First read the frame scans to get the frame-scan mapping in case the continous scans are missing
         frame_scans = self.read_frame_scans()
 

--- a/uimfpy/UIMFReader.py
+++ b/uimfpy/UIMFReader.py
@@ -1,29 +1,34 @@
 import sqlite3
-import pandas as pd
-import numpy as np
 import time
 
-from uimfpy.utils import decode, decompress
-from uimfpy.MzCalibrator import MzCalibrator
-
+import numpy as np
+import pandas as pd
 from scipy.signal import find_peaks
+from uimfpy.MzCalibrator import MzCalibrator
+from uimfpy.utils import decode, decompress
+
 
 class UIMFReader(object):
     """UIMFReader"""
+
     def __init__(self, uimf_file, TIC_threshold=None):
         self.uimf_file = uimf_file
         self.TIC_threshold = TIC_threshold
-        
+
         self.global_params = self.__run_query('SELECT * FROM Global_Params;')
         self.frame_params = self.__run_query('SELECT * FROM V_Frame_Params;')
-        
-        self.__calibration_params_by_frame = self.frame_params.pivot(index='FrameNum', columns='ParamName', values='ParamValue')\
-            [['CalibrationSlope','CalibrationIntercept']].to_dict(orient='index')
-        self.__bin_width = self.global_params[self.global_params.ParamName=="BinWidth"].ParamValue.tolist()[0]
-        self.__num_frames = int(self.global_params[self.global_params.ParamName=="NumFrames"].ParamValue.tolist()[0])
-        self.__num_scans = int(self.global_params[self.global_params.ParamName=="PrescanTOFPulses"].ParamValue.tolist()[0])
+
+        self.__calibration_params_by_frame = self.frame_params.pivot(index='FrameNum', columns='ParamName', values='ParamValue')[
+            ['CalibrationSlope', 'CalibrationIntercept']].to_dict(orient='index')
+        self.__bin_width = self.global_params[self.global_params.ParamName == "BinWidth"].ParamValue.tolist()[
+            0]
+        self.__num_frames = int(
+            self.global_params[self.global_params.ParamName == "NumFrames"].ParamValue.tolist()[0])
+        self.__num_scans = int(
+            self.global_params[self.global_params.ParamName == "PrescanTOFPulses"].ParamValue.tolist()[0])
         self.__average_TOF_length_by_frame = self.__get_average_TOF_lengths()
-        self.__TOF_lengths_by_frame = [self.__average_TOF_length_by_frame[f] for f in self.__average_TOF_length_by_frame]
+        self.__TOF_lengths_by_frame = [
+            self.__average_TOF_length_by_frame[f] for f in self.__average_TOF_length_by_frame]
         self.__average_TOF_length = np.mean(self.__TOF_lengths_by_frame)
         self.__stdv_TOF_length = np.std(self.__TOF_lengths_by_frame)
         self.mz_calibrator_by_params = dict()
@@ -34,47 +39,56 @@ class UIMFReader(object):
     @property
     def calibration_params_by_frame(self):
         return self.__calibration_params_by_frame
+
     @property
     def bin_width(self):
         return float(self.__bin_width)
+
     @property
     def num_bins_per_scan(self):
         return int(self.__average_TOF_length/self.bin_width)
+
     @property
     def num_frames(self):
         return self.__num_frames
+
     @property
     def num_scans(self):
         return self.__num_scans
-    
+
     def get_start_times(self):
         return self.__run_query("select FrameNum, ParamValue from frame_Params where ParamID = 1")
 
     def drift_ms(self, scan_num):
         return self.__average_TOF_length * scan_num * 1e-6
-    
+
     def average_TOF_length(self, frame=None):
-        if frame: return self.__average_TOF_length_by_frame[frame]
-        else: return self.__average_TOF_length
-        
+        if frame:
+            return self.__average_TOF_length_by_frame[frame]
+        else:
+            return self.__average_TOF_length
+
     def __run_query(self, query):
         conn = sqlite3.connect(self.uimf_file)
         df = pd.read_sql_query(query, conn)
         conn.close()
         return df
-    
+
     def summary(self):
         print("#"*100)
-        print("# Average TOF length: {:.1f} ({:.1f})".format(self.__average_TOF_length, self.__stdv_TOF_length))
+        print("# Average TOF length: {:.1f} ({:.1f})".format(
+            self.__average_TOF_length, self.__stdv_TOF_length))
         print("# M/Z calibrators by params: {}".format(self.mz_calibrator_by_params))
         print("#"*100)
 
     def read_frame_scans(self, frame_nums=None, scan_nums=None):
         selected_columns = "FrameNum,ScanNum,Intensities,NonZeroCount"
         if frame_nums is not None:
-            if isinstance(frame_nums, int): frame_nums = [frame_nums]
+            if isinstance(frame_nums, int):
+                frame_nums = [frame_nums]
         if scan_nums is not None:
-            if isinstance(scan_nums, int): scan_nums = [scan_nums]
+            if isinstance(scan_nums, int):
+                scan_nums = [scan_nums]
         if (frame_nums is None) & (scan_nums is None):
             query = 'SELECT {0} FROM Frame_Scans'.format(selected_columns)
         elif (frame_nums is None) & (scan_nums is not None):
@@ -86,62 +100,65 @@ class UIMFReader(object):
         else:
             query = 'SELECT {0} FROM Frame_Scans WHERE ScanNum IN ({1}) AND FrameNum IN ({2})'.format(
                 selected_columns, ','.join(str(x) for x in scan_nums), ','.join(str(x) for x in frame_nums))
-        
+
         if self.TIC_threshold is not None:
             query += " AND TIC>{0}".format(self.TIC_threshold)
-        
+
         #print('query:', query)
         frame_scans = self.__run_query(query)
         return frame_scans
-    
+
     def __count_frame_scans(self, frame_num=None):
         if frame_num is None:
             query = 'SELECT COUNT(*) FROM Frame_Scans;'
         else:
-            query = 'SELECT COUNT(*) FROM Frame_Scans WHERE FrameNum = {0};'.format(frame_num)
+            query = 'SELECT COUNT(*) FROM Frame_Scans WHERE FrameNum = {0};'.format(
+                frame_num)
         count_frame_scans = self.__run_query(query)
         return count_frame_scans
-    
+
     def __get_params(self, table, param_name):
-        return table[table.ParamName==param_name]
-    
+        return table[table.ParamName == param_name]
+
     def __get_average_TOF_lengths(self):
         df = self.__get_params(self.frame_params, 'AverageTOFLength')
-        average_TOF_length_by_frame = df[['FrameNum','ParamValue']]
+        average_TOF_length_by_frame = df[['FrameNum', 'ParamValue']]
         avg_tof_length = dict()
         for r in average_TOF_length_by_frame.to_dict('records'):
             avg_tof_length[r['FrameNum']] = float(r['ParamValue'])
         return avg_tof_length
 
     def get_mz_calibrator(self, frame_num=1):
-        if frame_num not in self.calibration_params_by_frame: return None
-        
+        if frame_num not in self.calibration_params_by_frame:
+            return None
+
         params = self.calibration_params_by_frame[frame_num]
         slope, intercept = params['CalibrationSlope'], params['CalibrationIntercept']
-        
+
         if (slope, intercept, self.bin_width) in self.mz_calibrator_by_params:
             return self.mz_calibrator_by_params[(slope, intercept, self.bin_width)]
         else:
             mzCalibrator = MzCalibrator(float(slope) / 10000.0,
                                         float(intercept) * 10000.0,
                                         float(self.bin_width))
-            self.mz_calibrator_by_params[(slope, intercept, self.bin_width)] = mzCalibrator
+            self.mz_calibrator_by_params[(
+                slope, intercept, self.bin_width)] = mzCalibrator
             return mzCalibrator
-    
+
     def __get_scan(self, frame_scans, frame_num, scan_num=None):
         if scan_num is None:
-            return frame_scans[frame_scans.FrameNum==frame_num]
+            return frame_scans[frame_scans.FrameNum == frame_num]
         elif isinstance(scan_num, int):
             scan_num = [scan_num]
-        return frame_scans[(frame_scans.FrameNum==frame_num) & (frame_scans.ScanNum.isin(scan_num))]
-    
+        return frame_scans[(frame_scans.FrameNum == frame_num) & (frame_scans.ScanNum.isin(scan_num))]
+
     def __mz_binning(self, frame_arr, scan_arr, int_arr, calibrated=True):
         stime = time.time()
         mz_intensities = dict()
         mzbin_ranges = None
         for f, s, i in zip(frame_arr, scan_arr, int_arr):
             mz_calibrator = self.get_mz_calibrator(frame_num=f)
-            
+
             bin_intensities = decode(decompress(i))
             num_bins = len(bin_intensities)
             _mz_arr = np.zeros(num_bins)
@@ -150,9 +167,11 @@ class UIMFReader(object):
                 _mz_arr[k] = idx
                 _int_arr[k] = intensity
             if calibrated:
-                mz_intensities[(f, s)] = {"mz":mz_calibrator.BinToMZ(_mz_arr), "int":_int_arr}
+                mz_intensities[(f, s)] = {
+                    "mz": mz_calibrator.BinToMZ(_mz_arr), "int": _int_arr}
             else:
-                mz_intensities[(f, s)] = {"mz":_mz_arr.astype(np.uint32), "int":_int_arr}
+                mz_intensities[(f, s)] = {"mz": _mz_arr.astype(
+                    np.uint32), "int": _int_arr}
         print("mz_binning for nrows:{0}, Done: Time: {1:.3f} s".format(
             len(frame_arr), time.time()-stime))
         return mz_intensities
@@ -163,14 +182,15 @@ class UIMFReader(object):
                                  df.ScanNum.values,
                                  df.Intensities.values,
                                  calibrated
-                                )
-        
+                                 )
+
     def __get_drift_ms(self, frame_num, scan_num):
         return self.__average_TOF_length_by_frame[frame_num] * scan_num * 1e-6
-    
+
     def get_mzbin_ranges_by_mz_window(self, start_mz, end_mz=None, ppm=None, Da=None):
-        if end_mz is None: end_mz = start_mz
-        if ((ppm is not None) and (Da is not None))|((ppm is None) and (Da is None)): 
+        if end_mz is None:
+            end_mz = start_mz
+        if ((ppm is not None) and (Da is not None)) | ((ppm is None) and (Da is None)):
             print("[ERR] either ppm or Da should be None")
             return None
         mz_calibrator_by_params = self.mz_calibrator_by_params
@@ -200,14 +220,16 @@ class UIMFReader(object):
         '''get the intesity levels for a range of mz bins
             mzbin_ranges: [min_mzbin, max_mzbin]
         '''
-        if len(mzbin_ranges)!=2:
+        if len(mzbin_ranges) != 2:
             print("[ERR] mzbin_ranges: [min_mzbin, max_mzbin]")
             return None
-        if  mzbin_ranges[0]>mzbin_ranges[1]:
-            print("[ERR] mzbin_ranges: [min_mzbin, max_mzbin], mzbin_ranges[0]<=mzbin_ranges[1]")
+        if mzbin_ranges[0] > mzbin_ranges[1]:
+            print(
+                "[ERR] mzbin_ranges: [min_mzbin, max_mzbin], mzbin_ranges[0]<=mzbin_ranges[1]")
             return None
         stime = time.time()
-        intensities_by_mzbins = { i : 0 for i in range(mzbin_ranges[0], mzbin_ranges[1]+1) }
+        intensities_by_mzbins = {i: 0 for i in range(
+            mzbin_ranges[0], mzbin_ranges[1]+1)}
         for f, s, i in zip(frame_arr, scan_arr, int_arr):
             bin_intensities = decode(decompress(i))
             for idx, intensity in bin_intensities:
@@ -222,27 +244,31 @@ class UIMFReader(object):
             given mono_mz, we use [mono_mz-1.2, mono_mz+2.2] window
         '''
         # collect mz bins
-        mzbin_ranges = self.get_mzbin_ranges_by_mz_window(mono_mz-1.2, mono_mz+2.2, Da=0)
-        mzbin_ranges = next(iter(mzbin_ranges.values()))  # TODO: use the first param
+        mzbin_ranges = self.get_mzbin_ranges_by_mz_window(
+            mono_mz-1.2, mono_mz+2.2, Da=0)
+        # TODO: use the first param
+        mzbin_ranges = next(iter(mzbin_ranges.values()))
         # collect intensities within a range
         df = self.read_frame_scans(frame_nums=frame_nums, scan_nums=scan_nums)
-        intensities_by_mzbins = self.get_intensities_by_mzbins(df.FrameNum.values, df.ScanNum.values, df.Intensities.values, mzbin_ranges)
+        intensities_by_mzbins = self.get_intensities_by_mzbins(
+            df.FrameNum.values, df.ScanNum.values, df.Intensities.values, mzbin_ranges)
         mz_bins = np.array([i for i in intensities_by_mzbins])
-        mz_int = np.array([intensities_by_mzbins[i] for i in intensities_by_mzbins])
+        mz_int = np.array([intensities_by_mzbins[i]
+                          for i in intensities_by_mzbins])
         # find peaks based on the intensity levels
         peaks_idx, _ = find_peaks(mz_int, distance=distance)
-        valid_peak_idxs = peaks_idx[mz_int[peaks_idx]>np.max(mz_int)*0.1]
+        valid_peak_idxs = peaks_idx[mz_int[peaks_idx] > np.max(mz_int)*0.1]
         mz_arr = self.get_mz(mz_bins)
         mz_arr = next(iter(mz_arr.values()))  # TODO: use the first param
-        
+
         peak_mz = mz_arr[valid_peak_idxs]
         ppm_errors = 1e6*np.abs(peak_mz-mono_mz)/mono_mz
-        
+
         # find the charge state from the target mono m/z
         mono_peak_idx = np.argmin(ppm_errors)
         main_peak_mz = mz_arr[valid_peak_idxs[mono_peak_idx]]
         charge_state = 0
-        for z in [5,4,3,2,1]:
+        for z in [5, 4, 3, 2, 1]:
             delta = 1/z
             is_true_charge = True
             for iso in range(1, 3):
@@ -258,27 +284,28 @@ class UIMFReader(object):
         # peak_diff = np.diff(peak_mz)
         # charge_state = (1/peak_diff).mean().round()
         return charge_state, mz_arr, mz_int, valid_peak_idxs
-    
+
     def __get_xic_target_mzbins(self, frame_arr, scan_arr, int_arr, target_mzbins, xic_by_mzbin, th=50):
         for f, s, i in zip(frame_arr, scan_arr, int_arr):
             params = self.calibration_params_by_frame[f]
             slope, intercept = params['CalibrationSlope'], params['CalibrationIntercept']
             target_mzbin = target_mzbins[(slope, intercept, self.bin_width)]
-            
+
             bin_intensities = decode(decompress(i))
             for idx, intensity in bin_intensities:
                 if intensity > th:
                     if idx in target_mzbin:
-                        if idx not in xic_by_mzbin: xic_by_mzbin[idx] = []
-                        xic_by_mzbin[idx].append([f,s,intensity])
+                        if idx not in xic_by_mzbin:
+                            xic_by_mzbin[idx] = []
+                        xic_by_mzbin[idx].append([f, s, intensity])
 
     def get_xic_by_target_mzbins(self, frame_start, frame_end, scan_start, scan_end, target_mzbins, sig_th=50, padding_frames=10, padding_scans=10):
         stime = time.time()
         xic_by_mzbin = dict()
-        df = self.read_frame_scans(frame_nums=list(range(frame_start-padding_frames,frame_end+padding_frames)),
-                                     scan_nums=list(range(scan_start-padding_scans,scan_end+padding_scans)))
+        df = self.read_frame_scans(frame_nums=list(range(frame_start-padding_frames, frame_end+padding_frames)),
+                                   scan_nums=list(range(scan_start-padding_scans, scan_end+padding_scans)))
         self.__get_xic_target_mzbins(df.FrameNum.values, df.ScanNum.values, df.Intensities.values,
-            target_mzbins, xic_by_mzbin, sig_th)
+                                     target_mzbins, xic_by_mzbin, sig_th)
         print("Frame:[{0}-{1}], Scan:[{2}-{3}] Done: Time: {4:.3f} s".format(
             frame_start,
             frame_end,
@@ -289,63 +316,78 @@ class UIMFReader(object):
         for mzbin in xic_by_mzbin:
             _l = xic_by_mzbin[mzbin]
             arr = np.array(_l)
-            xic_by_mzbin[mzbin] = coo_matrix((arr[:,2], (arr[:,0],arr[:,1])), shape=(self.num_frames+1, self.num_scans+1))
+            xic_by_mzbin[mzbin] = coo_matrix((arr[:, 2], (arr[:, 0], arr[:, 1])), shape=(
+                self.num_frames+1, self.num_scans+1))
             _l = None
             arr = None
-        
+
         return xic_by_mzbin
 
     def get_data_in_deimos_format(self):
-        # First read the frame scans to get the frame-scan mapping in case the continous scans are missing 
+        # First read the frame scans to get the frame-scan mapping in case the continous scans are missing
         frame_scans = self.read_frame_scans()
-        
-        # Now we need retention time or start time along with the frame numbers and frame type 
-        retention_time = self.__run_query('SELECT FrameNum,StartTime, FrameType FROM Frame_Parameters;')
+
+        # Now we need retention time or start time along with the frame numbers and frame type
+        retention_time = self.__run_query(
+            'SELECT FrameNum,StartTime, FrameType FROM Frame_Parameters;')
+
         # Check for the Frame types
         FrameType = set(list(retention_time["FrameType"]))
-        
-        #Need to create mapping to separate the data into frame types and then frame numbers wrt to their starttime for later
+
+        # Need to create mapping to separate the data into frame types 
+        # and then frame numbers wrt to their start time for later
         mapping = {}
         for ftype in FrameType:
             mapping[ftype] = {}
-            currentdf = retention_time.loc[retention_time["FrameType"]==ftype]
+            currentdf = retention_time.loc[retention_time["FrameType"] == ftype]
 
             for r in range(len(currentdf)):
-                mapping[ftype][currentdf.iloc[r]["FrameNum"]] = currentdf.iloc[r]["StartTime"]
-        
-        # Initilize a dictionary to save the results for different frametypes 
+                mapping[ftype][currentdf.iloc[r]["FrameNum"]
+                               ] = currentdf.iloc[r]["StartTime"]
+
+        # Initialize a dictionary to save the results for different frametypes
         finalresult = {}
-        
-        #Iterating through all frame types
+
+        # Iterate through all frame types
         for ftype in FrameType:
             # Getting all the frame numbers in int from the mapping
             frames_type = list(mapping[ftype].keys())
             frames_type = [int(i) for i in frames_type]
-            
-            #Initilizing lists to convert the data in deimos format 
-            mz, intensity, drift, retension = [],[],[],[]
-            
-            #Iterating through all the frames in the frame type
+
+            # Initialize lists to convert the data in deimos format
+            mz, intensity, drift, retention = [], [], [], []
+
+            # Iterating through all the frames in the frame type
             for fr in frames_type:
-                all_scans = list(frame_scans.loc[frame_scans["FrameNum"]==fr]["ScanNum"])
-                
-                #Got all the scans in that frame and now iterating over the scans 
+                all_scans = list(
+                    frame_scans.loc[frame_scans["FrameNum"] == fr]["ScanNum"])
+
+                # Got all the scans in that frame and now iterating over the scans
                 for sc in all_scans:
-                    #get peaks for the frame number and scan pair 
+                    # Get peaks for the frame number and scan pair
                     result = self.get_mz_peaks(fr, sc)
-                    #Add mz values to mz list 
+
+                    # Add mz values to mz list
                     mz.extend(result[(fr, sc)]["mz"])
-                    #Add intensities to the intensity list 
-                    intensity.extend(result[(fr,sc)]["int"])
-                    #Add retension time and drift time. Here we need the single values to be converted into the lengths of mz-intensity result  
-                    retension.extend([mapping[ftype][fr]]*len(result[(fr,sc)]["mz"]))
-                    drifttime = self.__get_drift_ms(fr,sc)
-                    drift.extend([drifttime]*len(result[(fr,sc)]["mz"]))
-            #Form a dataframe for the frame type 
+
+                    # Add intensities to the intensity list
+                    intensity.extend(result[(fr, sc)]["int"])
+
+                    # Add retension time and drift time
+                    # Here we need the single values to be converted into the lengths of mz-intensity result
+                    retention.extend([mapping[ftype][fr]] *
+                                     len(result[(fr, sc)]["mz"]))
+                    drifttime = self.__get_drift_ms(fr, sc)
+                    drift.extend([drifttime]*len(result[(fr, sc)]["mz"]))
+
+            # Form a dataframe for the frame type
             data = pd.DataFrame()
             data["mz"] = np.array(mz)
             data["intensity"] = np.array(intensity)
             data["drift_time"] = np.array(drift)
-            data["retention_time"] = np.array(retension)
-            finalresult["ms"+str(ftype)] = data 
+            data["retention_time"] = np.array(retention)
+
+            # Store frame type
+            finalresult["ms"+str(ftype)] = data
+
         return finalresult

--- a/uimfpy/UIMFReader.py
+++ b/uimfpy/UIMFReader.py
@@ -172,8 +172,8 @@ class UIMFReader(object):
             else:
                 mz_intensities[(f, s)] = {"mz": _mz_arr.astype(
                     np.uint32), "int": _int_arr}
-        print("mz_binning for nrows:{0}, Done: Time: {1:.3f} s".format(
-            len(frame_arr), time.time()-stime))
+        # print("mz_binning for nrows:{0}, Done: Time: {1:.3f} s".format(
+        #     len(frame_arr), time.time()-stime))
         return mz_intensities
 
     def get_mz_peaks(self, frame_nums, scan_nums=None, calibrated=True):
@@ -306,12 +306,12 @@ class UIMFReader(object):
                                    scan_nums=list(range(scan_start-padding_scans, scan_end+padding_scans)))
         self.__get_xic_target_mzbins(df.FrameNum.values, df.ScanNum.values, df.Intensities.values,
                                      target_mzbins, xic_by_mzbin, sig_th)
-        print("Frame:[{0}-{1}], Scan:[{2}-{3}] Done: Time: {4:.3f} s".format(
-            frame_start,
-            frame_end,
-            scan_start,
-            scan_end,
-            time.time()-stime))
+        # print("Frame:[{0}-{1}], Scan:[{2}-{3}] Done: Time: {4:.3f} s".format(
+        #     frame_start,
+        #     frame_end,
+        #     scan_start,
+        #     scan_end,
+        #     time.time()-stime))
 
         for mzbin in xic_by_mzbin:
             _l = xic_by_mzbin[mzbin]
@@ -334,7 +334,7 @@ class UIMFReader(object):
         # Check for the Frame types
         FrameType = set(list(retention_time["FrameType"]))
 
-        # Need to create mapping to separate the data into frame types 
+        # Need to create mapping to separate the data into frame types
         # and then frame numbers wrt to their start time for later
         mapping = {}
         for ftype in FrameType:


### PR DESCRIPTION
Modifies `UIMFReader.get_data_in_deimos_format` as `UIMFReader.to_dataframe`. A nearly identical result is produced, differing only in that a dictionary potentially containing multiple `FrameType` keys was dropped, as the instrument does not currently support interleaved MS1 and MS2 anyways -- can revisit if this changes. Computation on a representative data file was reduced from ~15 minutes to 31.6 seconds, a 28-fold improvement.